### PR TITLE
Restrict events to `MAX_ITEMS`

### DIFF
--- a/lib/version.py
+++ b/lib/version.py
@@ -1,4 +1,4 @@
 # Version string. Examples:
 #  '3.0.0'
 #  '3.0.0-alpha9'
-__version__ = '3.0.1'
+__version__ = '3.0.2-alpha0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.9.3
+aiohttp==3.9.5
 libprobe==0.2.36


### PR DESCRIPTION
## Description

For large sites, more than 2000 events might be in the result. Each event is translated to an item and the limit of `MAX_ITEMS` (2000) might be reached. 

As a fix, restrict the events to the last (newest) `MAX_ITEMS` events.

This pull request also updates the `aiohttp` library to the latest version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test using alpha version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
